### PR TITLE
Fix navigation of Cloud link to navigate to the Cloud page.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -18,7 +18,7 @@
           <a class="nav-link" href="{{"/python" | relative_url }}">Python</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="{{"/about" | relative_url }}">Cloud</a>
+          <a class="nav-link" href="{{"/cloud" | relative_url }}">Cloud</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{"/about" | relative_url }}">Data Science</a>


### PR DESCRIPTION
Sorry, I messed up and did not include this change before. This will make clicking the Cloud link to actually navigate to the page.